### PR TITLE
Raise page header above main

### DIFF
--- a/assets/style.postcss
+++ b/assets/style.postcss
@@ -597,7 +597,6 @@ body > header {
 }
 
 body > main {
-	z-index: 0;
 	flex: 1;
 	position: relative;
 	padding: 2rem var(--content-margin) 1rem;

--- a/assets/style.postcss
+++ b/assets/style.postcss
@@ -487,6 +487,7 @@ button,
 }
 
 body > header {
+	z-index: 1;
 	position: relative;
 	padding: var(--min-padding);
 	--header-bg-center: calc(var(--min-padding) + .75em) calc(2em - var(--scrolltop, 0) * 1px);
@@ -596,6 +597,7 @@ body > header {
 }
 
 body > main {
+	z-index: 0;
 	flex: 1;
 	position: relative;
 	padding: 2rem var(--content-margin) 1rem;


### PR DESCRIPTION
Prevent social icons from becoming unreachable under main content.

closes #8 
closes #10 